### PR TITLE
Fix `ip` command not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:stable
 RUN apt-get update
 
 # Install non-python components
-RUN apt-get install bash net-tools -y
+RUN apt-get install bash net-tools iproute2 -y
 
 # Install python dependencies
 RUN apt-get install python3.9 python3-pip python3-openssl -y

--- a/docker_runserver.sh
+++ b/docker_runserver.sh
@@ -47,8 +47,8 @@ elif [[ ! $USERNAME && $PASSWORD ]]; then
     echo "Password supplied with no username. Exiting.";
     exit;
 else
-    echo "Credentials not supplied. Basic authentication disabled.";
-    exit;
+    echo "Credentials not supplied.";
+    echo "⚠️ WARNING: Basic authentication disabled!"
 fi
 
 # =====================


### PR DESCRIPTION
Fix `ip` command in the latest `debian:stable` release.